### PR TITLE
Possibility to use pre-running code-server instead of starting a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ socket file path.
 
 If none of these environment variables are set, jupyter-code-server starts new code-server process and proxies
 requests to its socket.
+
+### Enable/disable launcher
+By default code-server launcher is enabled and visible in JupyterLab. Option `JSP_CODE_SERVER_LAUNCHER_DISABLED`
+may be set to any non-empty value to disable launcher. This is useful when e.g. certain users are not supposed
+to have code-server available in Jupyterhub as there is no easy way to disable loading of entire `jupyter-code-server`
+module for these users if module is for example built into Docker image.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ An example of loading code-server via Lmod can be found in the branch lmod_pre_s
 [lmod_pre_start](https://github.com/mawigh/jupyter-code-server/tree/lmod_pre_start)
 
 **Important:** You might want to change the loaded code-server version.
+### Using pre-started code-server
+
+In case code-server is already running (e.g. started in sidecar container with Jupyter running in Kubernetes)
+and servig either via TCP port or UNIX socket, it is possible to proxy this already running instance instead
+of starting a new one with jupyter-server-proxy. Variables `JSP_CODE_SERVER_PORT` and `JSP_CODE_SERVER_SOCKET`
+set `command` to empty list which makes `jupyter-server-proxy` pass requests to specified port of socket.
+
+If running code-server is listening to TCP port, environment variable `JSP_CODE_SERVER_PORT` may be set to
+port number.
+
+If running code-server is listening to UNIX socket, environment variable `JSP_CODE_SERVER_SOCKET` may be set to
+socket file path.
+
+If none of these environment variables are set, jupyter-code-server starts new code-server process and proxies
+requests to its socket.

--- a/src/jupyter_code_server/__init__.py
+++ b/src/jupyter_code_server/__init__.py
@@ -25,7 +25,13 @@ def setup_code_server():
     proxy_config_dict = {
         "new_browser_window": True,
         "timeout": 30,
-        "launcher_entry": {"title": "VSCode Web IDE", "path_info": "vscode", "icon_path": os.path.join(_HERE, 'icons/vscode.svg')}
+        "launcher_entry": {
+            # Option to disable launcher, e.g. for users that are not supposed to have editor available
+            "enabled": False if os.environ.get('JSP_CODE_SERVER_LAUNCHER_DISABLED') else True,
+            "title": "VSCode Web IDE",
+            "path_info": "vscode",
+            "icon_path": os.path.join(_HERE, 'icons/vscode.svg')
+            }
         }
 
     # if code-server is already running and listening to TCP port


### PR DESCRIPTION
Sometimes code-server is already running (e.g. in sidecar container with Jupyter singleuser in Kubernetes). For these cases there is no need to start a new code-server process, it's possible to just proxy requests to TCP port or UNIX socket of already running code-server.